### PR TITLE
Ratings and reviews

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,9 @@ gem 'bcrypt', '3.1.9'
 gem 'bootstrap-sass', '~> 3.3.1.0'
 gem 'pg', '~> 0.18.1'
 gem 'faker'
+gem 'will_paginate',           '3.0.7'
+gem 'bootstrap-will_paginate', '0.0.10'
+
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,8 @@ GEM
     bcrypt (3.1.9-x86-mingw32)
     bootstrap-sass (3.3.1.0)
       sass (~> 3.2)
+    bootstrap-will_paginate (0.0.10)
+      will_paginate
     builder (3.2.2)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
@@ -101,6 +103,7 @@ GEM
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
     sqlite3 (1.3.10)
+    sqlite3 (1.3.10-x86-mingw32)
     thor (0.19.1)
     thread_safe (0.3.4)
     tilt (1.4.1)
@@ -113,6 +116,7 @@ GEM
     uglifier (2.6.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    will_paginate (3.0.7)
 
 PLATFORMS
   ruby
@@ -121,6 +125,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt (= 3.1.9)
   bootstrap-sass (~> 3.3.1.0)
+  bootstrap-will_paginate (= 0.0.10)
   coffee-rails (~> 4.0.0)
   faker
   jbuilder (~> 2.0)
@@ -134,3 +139,4 @@ DEPENDENCIES
   turbolinks
   tzinfo-data
   uglifier (>= 1.3.0)
+  will_paginate (= 3.0.7)

--- a/app/assets/javascripts/reviews.js.coffee
+++ b/app/assets/javascripts/reviews.js.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/reviews.css.scss
+++ b/app/assets/stylesheets/reviews.css.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Reviews controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -5,6 +5,7 @@ class GuidesController < ApplicationController
 
   def show
     @guide = Guide.find(params[:id])
+    @reviews = @guide.reviews.paginate(page: params[:page])
   end
 
   def new

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,0 +1,2 @@
+class ReviewsController < ApplicationController
+end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,2 +1,11 @@
 class ReviewsController < ApplicationController
+
+  private
+
+  def review_params
+    params.require(:review).permit(:user_id,
+                                   :guide_id,
+                                   :content,
+                                   :rating )
+  end
 end

--- a/app/helpers/reviews_helper.rb
+++ b/app/helpers/reviews_helper.rb
@@ -1,0 +1,2 @@
+module ReviewsHelper
+end

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -1,5 +1,6 @@
 class Guide < ActiveRecord::Base
   belongs_to :user
+  has_many :reviews
 
   validates :user_id,
     presence: true

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,0 +1,12 @@
+class Review < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :guide
+  default_scope -> { order(created_at: :desc) }
+
+  validates :user_id, presence: true
+
+  validates :guide_id, presence: true
+
+  validates :content, presence: true,
+            length: { maximum: 999 }
+end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -9,4 +9,8 @@ class Review < ActiveRecord::Base
 
   validates :content, presence: true,
             length: { maximum: 999 }
+
+  validates :rating, presence: true,
+            numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 5 }
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,6 @@ class User < ActiveRecord::Base
   has_one :guide
   has_many :reviews, dependent: :destroy
 
-
   before_save { self.email = email.downcase }
 
   validates :name,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,8 @@
 class User < ActiveRecord::Base
   has_one :guide
+  has_many :reviews, dependent: :destroy
+
+
   before_save { self.email = email.downcase }
 
   validates :name,

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -41,7 +41,49 @@
   <br>
 <% end %>
 
-<div class="col-md-8">
+<br>
+
+<!-- Rating Star display code starts here -->
+
+<strong>Overall Rating: </strong>
+<% if @guide.reviews.any? %>
+  <% average = @guide.reviews.average(:rating) %>
+<% else %>
+  <% average = 0 %>
+<% end %>
+
+<% parts = average.divmod(1) %>
+<% stars = parts[0] %>
+
+<% if parts[1] >= 0.5 %>
+  <% halfStar = true %>
+  <% blankStars = 4 - stars %>
+<% else %>
+  <% halfStar = false %>
+  <% blankStars = 5 - stars %>
+<% end %>
+
+<% stars.to_i.times do  %>
+  <!-- Uncomment below when Bootstrap is moved from Front End -->
+  <!-- <span class="fa fa-star"></span> -->
+  <span><b>FS</b></span>
+<% end %>
+
+<% if halfStar %>
+  <!-- Uncomment below when Bootstrap is moved from Front End -->
+  <!-- <span class="fa fa-star-half-o"></span> -->
+  <span><b>HS</b></span>
+<% end %>
+
+<% blankStars.to_i.times do %>
+  <!-- Uncomment below when Bootstrap is moved from Front End -->
+  <!-- <span class="fa fa-star-o"></span> -->
+  <span><b>BS</b></span>
+<% end %>
+
+<!-- Rating Star display ends here -->
+
+  <div class="col-md-8">
   <% if @guide.reviews.any? %>
     <h3>Reviews (<%= @guide.reviews.count %>)</h3>
     <ol class="reviews">

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -40,3 +40,13 @@
   <b>Saturday</b>
   <br>
 <% end %>
+
+<div class="col-md-8">
+  <% if @guide.reviews.any? %>
+    <h3>Reviews (<%= @guide.reviews.count %>)</h3>
+    <ol class="reviews">
+      <%= render @reviews %>
+    </ol>
+    <%= will_paginate @reviews %>
+  <% end %>
+</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -100,7 +100,7 @@
                 <%= formElement.label :password%>
                 <%= formElement.password_field :password, class: 'form-control', id: 'Password', placeholder: 'Password' %>
               </div>
-              <br></br>
+              <br>
               <div class='form-group'>
                 <button class="btn btn-danger"> Reset </button>
                 <%= formElement.submit "Submit", class: 'btn btn-success' %>

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -2,6 +2,6 @@
   <span class="user"><%= link_to review.user.name, review.user %></span>
   <span class="content"><%= review.content %></span>
   <span class="timestamp">
-    Posted <%= time_ago_in_words(reviwe.created_at) %> ago.
+    Posted <%= time_ago_in_words(review.created_at) %> ago.
   </span>
 </li>

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -1,0 +1,7 @@
+<li id="review-<%= review.id %>">
+  <span class="user"><%= link_to review.user.name, review.user %></span>
+  <span class="content"><%= review.content %></span>
+  <span class="timestamp">
+    Posted <%= time_ago_in_words(reviwe.created_at) %> ago.
+  </span>
+</li>

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -1,6 +1,7 @@
 <li id="review-<%= review.id %>">
   <span class="user"><%= link_to review.user.name, review.user %></span>
   <span class="content"><%= review.content %></span>
+  <span class="rating">Rating: <%= review.rating %></span>
   <span class="timestamp">
     Posted <%= time_ago_in_words(review.created_at) %> ago.
   </span>

--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -168,4 +168,4 @@
 
     <!-- Bootstrap Core JavaScript -->
     <script src="js/bootstrap.min.js"></script>
-  </body>
+</body>

--- a/db/migrate/20150121223419_create_reviews.rb
+++ b/db/migrate/20150121223419_create_reviews.rb
@@ -1,0 +1,12 @@
+class CreateReviews < ActiveRecord::Migration
+  def change
+    create_table :reviews do |t|
+      t.text :content
+      t.references :user, index: true
+      t.references :guide, index: true
+
+      t.timestamps
+    end
+    add_index :reviews, [:guide_id, :created_at]
+  end
+end

--- a/db/migrate/20150124185041_add_rating_to_reviews.rb
+++ b/db/migrate/20150124185041_add_rating_to_reviews.rb
@@ -1,0 +1,5 @@
+class AddRatingToReviews < ActiveRecord::Migration
+  def change
+    add_column :reviews, :rating, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,46 +11,52 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150121223419) do
+ActiveRecord::Schema.define(version: 20150124185041) do
 
-  create_table "guides", force: true do |tableObject|
-    tableObject.string "location"
-    tableObject.integer "user_id"
-    tableObject.datetime "created_at", null: false
-    tableObject.datetime "updated_at", null: false
-    tableObject.string "specialty"
-    tableObject.float "rate"
-    tableObject.boolean "availability", default: [false, false, false, false, false, false, false], array: true
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "guides", force: true do |t|
+    t.string   "location"
+    t.integer  "user_id"
+    t.datetime "created_at",                                                               null: false
+    t.datetime "updated_at",                                                               null: false
+    t.string   "specialty"
+    t.float    "rate"
+    t.boolean  "availability", default: [false, false, false, false, false, false, false],              array: true
   end
 
   add_index "guides", ["user_id"], name: "index_guides_on_user_id", using: :btree
 
-  create_table "reviews", force: true do |tableObject|
-    tableObject.text "content"
-    tableObject.integer "user_id"
-    tableObject.integer "guide_id"
-    tableObject.datetime "created_at"
-    tableObject.datetime "updated_at"
+  create_table "reviews", force: true do |t|
+    t.text     "content"
+    t.integer  "user_id"
+    t.integer  "guide_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer  "rating"
   end
 
   add_index "reviews", ["guide_id", "created_at"], name: "index_reviews_on_guide_id_and_created_at", using: :btree
   add_index "reviews", ["guide_id"], name: "index_reviews_on_guide_id", using: :btree
   add_index "reviews", ["user_id"], name: "index_reviews_on_user_id", using: :btree
 
-  create_table "users", force: true do |tableObject|
-    tableObject.string "name"
-    tableObject.string "email"
-    tableObject.datetime "created_at"
-    tableObject.datetime "updated_at"
-    tableObject.string "password_digest"
-    tableObject.string "phone_number"
-    tableObject.integer "age"
-    tableObject.text "profile"
-    tableObject.string "address"
-    tableObject.string "city"
-    tableObject.string "state"
-    tableObject.string "zipcode"
-    tableObject.string "country"
+  create_table "users", force: true do |t|
+    t.string   "name"
+    t.string   "email"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "password_digest"
+    t.string   "phone_number"
+    t.integer  "age"
+    t.text     "profile"
+    t.string   "address"
+    t.string   "city"
+    t.string   "state"
+    t.string   "zipcode"
+    t.string   "country"
   end
+
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150119232618) do
+ActiveRecord::Schema.define(version: 20150121223419) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,18 @@ ActiveRecord::Schema.define(version: 20150119232618) do
   end
 
   add_index "guides", ["user_id"], name: "index_guides_on_user_id", using: :btree
+
+  create_table "reviews", force: true do |t|
+    t.text     "content"
+    t.integer  "user_id"
+    t.integer  "guide_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "reviews", ["guide_id", "created_at"], name: "index_reviews_on_guide_id_and_created_at", using: :btree
+  add_index "reviews", ["guide_id"], name: "index_reviews_on_guide_id", using: :btree
+  add_index "reviews", ["user_id"], name: "index_reviews_on_user_id", using: :btree
 
   create_table "users", force: true do |t|
     t.string   "name"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -75,14 +75,16 @@ users.each { |user|
                 availability: availability)
 }
 
-reviewers = User.where(id: 41..50)
+reviewers = User.where(id: 41..60)
 10.times do
   reviewers.each { |reviewer|
     content = Faker::Lorem.sentences(5).join(" ")
     guide_id = rand(40) + 1
+    rating = rand(5) + 1
     Review.create!(user_id: reviewer.id,
                    guide_id: Guide.find(guide_id).id,
-                   content: content)
+                   content: content,
+                   rating: rating)
   }
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -75,6 +75,15 @@ users.each { |user|
                 availability: availability)
 }
 
-
+reviewers = User.where(id: 41..50)
+10.times do
+  reviewers.each { |reviewer|
+    content = Faker::Lorem.sentences(5).join(" ")
+    guide_id = rand(40) + 1
+    Review.create!(user_id: reviewer.id,
+                   guide_id: Guide.find(guide_id).id,
+                   content: content)
+  }
+end
 
 

--- a/test/controllers/reviews_controller_test.rb
+++ b/test/controllers/reviews_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ReviewsControllerTest < ActionController::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/guides.yml
+++ b/test/fixtures/guides.yml
@@ -1,9 +1,2 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  location: MyString
-  user_id: 
-
-two:
-  location: MyString
-  user_id: 

--- a/test/fixtures/reviews.yml
+++ b/test/fixtures/reviews.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+good:
+  content: "This guy was alright."
+  created_at: <%= 10.minutes.ago %>
+
+bad:
+  content: "This was awful."
+  created_at: <%= 5.minutes.ago %>
+
+most_recent:
+  content: "This was just posted."
+  created_at: <%= Time.zone.now %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,1 +1,5 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+test_user:
+ name: testing
+ email: test@test.com
+ password_digest: <%= User.digest('password') %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,5 +1,1 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-test_user:
-  name: testing
-  email: test@test.com
-  password_digest: <%= User.digest('password') %>

--- a/test/helpers/reviews_helper_test.rb
+++ b/test/helpers/reviews_helper_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class ReviewsHelperTest < ActionView::TestCase
+end

--- a/test/models/review_test.rb
+++ b/test/models/review_test.rb
@@ -1,0 +1,77 @@
+require 'test_helper'
+
+class ReviewTest < ActiveSupport::TestCase
+  def setup
+    @user1 = User.new(id: 1,
+        name: "Example Guide",
+        email: "guide@example.com",
+        phone_number: "503-555-4353",
+        age: 32,
+        password: "foobar",
+        password_confirmation: "foobar",
+        profile: 'Profile',
+        address: '123 Main St',
+        city: 'Anytown',
+        state: 'AL',
+        zipcode: '97124',
+        country: 'USA'
+    )
+
+    @guide = Guide.new(id: 1,
+                       user: @user,
+                       location: 'Mount Hood Meadows',
+                       specialty: 'Downhill Skiing',
+                       rate: 25,
+                       availability: [true, false, false, true, true, false, true]
+
+    )
+
+    @user2 = User.new(id: 2,
+                      name: "Example Reviewer",
+                      email: "reviewer@example.com",
+                      phone_number: "503-355-4353",
+                      age: 35,
+                      password: "foobar",
+                      password_confirmation: "foobar",
+                      profile: 'Profile',
+                      address: '123 Main St',
+                      city: 'Anytown',
+                      state: 'AL',
+                      zipcode: '97124',
+                      country: 'USA'
+    )
+
+    @review = Review.new(user: @user2,
+                         guide: @guide,
+                         content: 'This guy was terrible.'
+    )
+  end
+
+  test 'review should be valid' do
+    assert @review.valid?
+  end
+
+  test 'user_id should be present' do
+    @review.user_id = nil
+    assert_not @review.valid?
+  end
+
+  test 'guide_id should be present' do
+    @review.guide_id = nil
+    assert_not @review.valid?
+  end
+
+  test 'content should be present' do
+    @review.content = '   '
+    assert_not @review.valid?
+  end
+
+  test 'content should be less than 1000 characters' do
+    @review.content = 'a' * 1000
+    assert_not @review.valid?
+  end
+
+  test 'order should be most recent first' do
+    assert_equal Review.first, reviews(:most_recent)
+  end
+end

--- a/test/models/review_test.rb
+++ b/test/models/review_test.rb
@@ -66,8 +66,23 @@ class ReviewTest < ActiveSupport::TestCase
     assert_not @review.valid?
   end
 
+  test 'rating should be present' do
+    @review.rating = nil
+    assert_not @review.valid?
+  end
+
   test 'content should be less than 1000 characters' do
     @review.content = 'a' * 1000
+    assert_not @review.valid?
+  end
+
+  test 'rating should be greater or equal to 1' do
+    @review.rating = 0
+    assert_not @review.valid?
+  end
+
+  test 'rating should be less than or equal to 5' do
+    @review.rating = 6
     assert_not @review.valid?
   end
 

--- a/test/models/review_test.rb
+++ b/test/models/review_test.rb
@@ -43,7 +43,8 @@ class ReviewTest < ActiveSupport::TestCase
 
     @review = Review.new(user: @user2,
                          guide: @guide,
-                         content: 'This guy was terrible.'
+                         content: 'This guy was terrible.',
+                         rating: 4
     )
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -197,7 +197,7 @@ class UserTest < ActiveSupport::TestCase
 
   test "associated reviews should be deleted" do
     @user.save
-    @user.reviews.create!(guide: @guide, content: "Test test test")
+    @user.reviews.create!(guide: @guide, content: "Test test test", rating: 3)
     assert_difference 'Review.count', -1 do
       @user.destroy
     end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -22,6 +22,30 @@ class UserTest < ActiveSupport::TestCase
       zipcode: '97124',
       country: 'USA'
     )
+
+    @user1 = User.new(id: 1,
+                      name: "Example Guide",
+                      email: "guide@example.com",
+                      phone_number: "503-555-4353",
+                      age: 32,
+                      password: "foobar",
+                      password_confirmation: "foobar",
+                      profile: 'Profile',
+                      address: '123 Main St',
+                      city: 'Anytown',
+                      state: 'AL',
+                      zipcode: '97124',
+                      country: 'USA'
+    )
+
+    @guide = Guide.new(id: 1,
+                       user: @user,
+                       location: 'Mount Hood Meadows',
+                       specialty: 'Downhill Skiing',
+                       rate: 25,
+                       availability: [true, false, false, true, true, false, true]
+
+    )
   end
 
   test "should be valid" do
@@ -168,4 +192,16 @@ class UserTest < ActiveSupport::TestCase
     @user.profile = "b" * 1000
     assert_not @user.valid?
   end
+
+  # Ensures deletion of reviews on deletion of a user
+
+  test "associated reviews should be deleted" do
+    @user.save
+    @user.reviews.create!(guide: @guide, content: "Test test test")
+    assert_difference 'Review.count', -1 do
+      @user.destroy
+    end
+  end
+
+
 end


### PR DESCRIPTION
Reviews portion done. Added ratings to be a part of reviews. Front end people, the code to display the correct number of stars for ratings is found in  app/views/guides/show.html.erb lines 46-84. I don't think the package Melissa used for stars on her profile page is configured on this repository, because using the same lines generated nothing. Replaced them with Dummy FS (full star), HS (half star) and BS (blank star) as seen here:
![rating](https://cloud.githubusercontent.com/assets/9941593/5888763/ebe9783a-a3c0-11e4-94a1-cfc91eacd1ee.jpg)

But, anyway, when we get to generating real profile pages, we can just copy that code in to the profile page code. 

Running rake:test still fails the tests mentioned in #19 tests, but also generates an HTML warning: ignoring attempt to close ul with li
  opened at byte 973, line 26
  closed at byte 2386, line 73

So there is a tag mismatch that I believe to be in _header.html.erb. I didn't touch that file, so that needs to be looked at. Not a huge deal since the page still renders.

Oh, and the t to tableObject change in Harman's pull request was reverted. Each time we do a rails migration, the schema.db file is updated automatically and it defaults to using t. So, that's why t is back instead of tableObject. 