### PR TITLE
Fixed password page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -64,7 +64,7 @@ class UsersController < ApplicationController
   def logged_in_user
     unless logged_in?
       store_location
-      flash.now[:danger] = "Please log in."
+      flash[:danger] = "Please log in."
       redirect_to login_url
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,7 +28,7 @@ class UsersController < ApplicationController
   def update
     @user = User.find(params[:id])
 
-    if params[:user][:password].blank?
+    if params[:user][:password].nil?
       if @user.update(user_params)
         flash[:success] = 'Profile has been updated'
         redirect_to @user
@@ -37,13 +37,16 @@ class UsersController < ApplicationController
       end
     else
       if not @user.authenticate(params[:current_password])
-        flash[:danger] = 'You old password is not valid'
-        render 'change_password'
-      elsif params[:user][:password] != params[:user][:password_confirmation]
-        flash[:danger] = 'Unmatch new password'
+        flash.now[:danger] = 'Your current password is not valid'
         render 'change_password'
       else
-        if @user.update(user_params)
+        if params[:user][:password].blank?
+          flash.now[:danger] = 'No new password entered'
+          render 'change_password'
+        elsif params[:user][:password] != params[:user][:password_confirmation]
+          flash.now[:danger] = 'New password does not match confirmation'
+          render 'change_password'
+        elsif @user.update(user_params)
           flash[:success] = 'Your password has been updated'
           redirect_to @user
         else
@@ -61,7 +64,7 @@ class UsersController < ApplicationController
   def logged_in_user
     unless logged_in?
       store_location
-      flash[:danger] = "Please log in."
+      flash.now[:danger] = "Please log in."
       redirect_to login_url
     end
   end

--- a/app/views/users/change_password.html.erb
+++ b/app/views/users/change_password.html.erb
@@ -5,8 +5,6 @@
     <form class='form-horizontal'>
       <%= render 'shared/error_messages' %>
 
-      <%= hidden_field_tag(:changing_password, true) %>
-
       <div class='form-group'>
         <%= formElement.label 'Current password', class: 'col-sm-2 control-label' %>
         <%= password_field_tag 'current_password' %>
@@ -30,5 +28,5 @@
 
     </form>
 
-    <%= button_to 'Cancel', 'edit', :method => 'get' %>
+    <%= link_to "Cancel", edit_user_url(id: @user.id),  class: "btn btn-default"%>
 <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -8,15 +8,10 @@
     <form class='form-horizontal'>
       <%= render 'shared/error_messages' %>
 
-      <%= hidden_field_tag(:changing_password, false) %>
-
       <div class='form-group'>
         <%= formElement.label :name, class: 'col-sm-2 control-label' %>
         <%= formElement.text_field :name %>
       </div>
-
-      <%= hidden_field(:password, :method => '') %>
-      <%= hidden_field(:password_confirmation, :method => '') %>
 
       <div class='form-group'>
         <%= formElement.label :email, class: 'col-sm-2 control-label' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root                'static_pages#index'
+  root   'static_pages#home'
   get    'contact'                   => 'static_pages#contact'
   get    'about'                     => 'static_pages#about'
   get    'faq'                       => 'static_pages#faq'


### PR DESCRIPTION
After AJ's fixes before the edit-profile merge, a few bugs popped up. A major one was where the user would be redirected to the user#show page if they entered a bogus current_password, saying they changed their profile (as if they updated their other profile information instead of their password). The control structure for new password validation has been fixed and unused variables were removed. Lastly, I changed the root path in the routes.rb file since root is now 'home' instead of 'index'. 