### PR TITLE
Added functionality to give a list of guides for each location

### DIFF
--- a/app/views/guides/index.html.erb
+++ b/app/views/guides/index.html.erb
@@ -1,4 +1,8 @@
-<h1>Listing Guides</h1>
+<% if !params[:location].nil? %>
+  <h1>Guides for <%=params[:location]%></h1>
+<% else %>
+  <h1>Guide Listing</h1>
+<% end %>
 
 <style>
 table, th, td {
@@ -24,16 +28,31 @@ th, td {
   </thead>
 
   <% Array(@guides).each do |guide| %>
-    <tr>
-      <td><%= guide.user.name %></td>
-      <td><%= guide.user.email %></td>
-      <td><%= location_string(guide.hood, guide.bachelor, guide.whistler) %></td>
-      <td><%= sports_string(guide.downhill, guide.crosscountry, guide.snowboard) %></td>
-      <td><%= if !guide.reviews.empty? then guide.reviews.average(:rating).to_s
-              else "N/A" end %></td>
-      <td><%= link_to 'Show', guide %></td>
+    <% if !params[:location].nil? %>
+      <% loc_str = location_string(guide.hood, guide.bachelor, guide.whistler) %>
+      <% if loc_str.include?(params[:location]) %>
+        <tr>
 
-    </tr>
+          <td><%= guide.user.name %></td>
+          <td><%= guide.user.email %></td>
+          <td><%= loc_str %></td>
+          <td><%= sports_string(guide.downhill, guide.crosscountry, guide.snowboard) %></td>
+          <td><%= if !guide.reviews.empty? then guide.reviews.average(:rating).to_s
+                  else "N/A" end %></td>
+          <td><%= link_to 'Show', guide %></td>
+        </tr>
+      <% end %>
+    <% else %>
+      <tr>
+        <td><%= guide.user.name %></td>
+        <td><%= guide.user.email %></td>
+        <td><%= location_string(guide.hood, guide.bachelor, guide.whistler) %></td>
+        <td><%= sports_string(guide.downhill, guide.crosscountry, guide.snowboard) %></td>
+        <td><%= if !guide.reviews.empty? then guide.reviews.average(:rating).to_s
+                else "N/A" end %></td>
+        <td><%= link_to 'Show', guide %></td>
+      </tr>
+    <% end %>
   <% end %>
 </table>
 

--- a/app/views/guides/mtbachelor.html.erb
+++ b/app/views/guides/mtbachelor.html.erb
@@ -49,7 +49,9 @@
   <!-- Related Projects Row -->
   <div class="row">
     <div class="col-lg-12">
-      <h3 class="page-header">Top Guides for Mt. Bachelor</h3>
+      <h3 class="page-header">Top Guides for Mt. Bachelor
+        <%= link_to 'More Guides', index_path(location: 'Mount Bachelor'), class: "btn btn-default" %>
+      </h3>
     </div>
 
     <% top_guides = top_guides(bachelor_guides) %>

--- a/app/views/guides/mthood.html.erb
+++ b/app/views/guides/mthood.html.erb
@@ -60,7 +60,10 @@
   <div class="row">
 
     <div class="col-lg-12">
-      <h3 class="page-header">Top Guides for Mt. Hood</h3>
+      <h3 class="page-header">Top Guides for Mt. Hood
+        <%= link_to 'More Guides', index_path(location: 'Mount Hood'), class: "btn btn-default" %>
+      </h3>
+
     </div>
 
     <% top_guides = top_guides(hood_guides) %>

--- a/app/views/guides/mtwhistler.html.erb
+++ b/app/views/guides/mtwhistler.html.erb
@@ -60,7 +60,9 @@
   <div class="row">
 
     <div class="col-lg-12">
-      <h3 class="page-header">Top Guides for Mt. Whistler</h3>
+      <h3 class="page-header">Top Guides for Mt. Whistler
+        <%= link_to 'More Guides', index_path(location: 'Whistler'), class: "btn btn-default" %>
+      </h3>
     </div>
 
     <% top_guides = top_guides(whistler_guides) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
   post   'review'                         => 'reviews#new'
   post   'login'                          => 'sessions#create'
   delete 'logout'                         => 'sessions#destroy'
+  get    'guides'                         => 'guides#index', as: 'index'
 
   resources :users
   resources :guides


### PR DESCRIPTION
This fix adds onto our existing guide listing page. A button on each of the location pages leads to the index page (/guides url path) and gives a location parameter to the index page. If the index page sees that the location param is not null, it gives a list of guides that are part of that location. Otherwise, if there are no parameters (someone just goes directly to the index page), they'll see a list of all guides (this is the functionality that we had before).
